### PR TITLE
Added support for merging video and overlay file into one video file

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,7 @@ You can export a JSON file with info about downloaded snaps with the `--write-js
 #### Snap Radius
 
 The radius from the coordinates you provide that will be included for downloads. `-r 20000` will download all Snaps within a 20km radius of your coordinates.
+
+#### No Overlay
+
+By default the script merges the video and the overlay file into one file. With the `--no-overlay` argument you can disable this and only download the raw video.  

--- a/snapmap_archiver/__init__.py
+++ b/snapmap_archiver/__init__.py
@@ -11,7 +11,7 @@ def main():
     parser.add_argument('-z', dest='zoom_depth', type=float, help='Snapmaps zoom depth, default is 5.')
     parser.add_argument('-r', dest='radius', type=int, help='Maximum Snap radius in meters, default is 10000.')
     parser.add_argument('--write-json', dest='write_json', action='store_true', default=False, help='Write Snap metadata JSON.')
-    parser.add_argument('--use-ffmpeg', dest='use_ffmpeg', action='store_true', default=False, help='Use ffmpeg to merge graphical elements to video Snaps.')
+    parser.add_argument('--no-overlay', dest='no_overlay', action='store_true', default=False, help='Do not use ffmpeg to merge graphical elements to video Snaps. Default is False')
     args = parser.parse_args()
 
     if(not args.output_dir):
@@ -42,5 +42,5 @@ def main():
     except:
         sys.exit(geo_msg)
     api_response = get_data.api_query(float(geo_data[0]), float(geo_data[1]), max_radius=args.radius)
-    download_media(args.output_dir, organise_media(api_response), args.write_json)
+    download_media(args.output_dir, organise_media(api_response), args.write_json, args.no_overlay)
     

--- a/snapmap_archiver/utils/__init__.py
+++ b/snapmap_archiver/utils/__init__.py
@@ -16,7 +16,7 @@ def organise_media(api_data):
             data_dict['media']['raw_url'] = entry['snapInfo']['streamingMediaInfo']['prefixUrl'] + 'media.mp4'
             data_dict['media']['filetype'] = "mp4"
             try:
-                data_dict['media']['video_overlay'] = entry['snapInfo']['streamingMediaInfo']['prefixUrl'] + 'overlay.png'
+                data_dict['media']['video_overlay'] = entry['snapInfo']['streamingMediaInfo']['prefixUrl'] + entry['snapInfo']['streamingMediaInfo']['overlayUrl']
             except:
                 data_dict['media']['video_overlay'] = None
         except:

--- a/snapmap_archiver/utils/__init__.py
+++ b/snapmap_archiver/utils/__init__.py
@@ -9,7 +9,12 @@ def organise_media(api_data):
             if(locale['locale'] == 'en'):
                 data_dict['location'] = locale['text']
         try:
+            data_dict['media']['overlayText'] = entry['snapInfo']['overlayText']
+        except:
+            data_dict['media']['overlayText'] = None
+        try:
             data_dict['media']['raw_url'] = entry['snapInfo']['streamingMediaInfo']['prefixUrl'] + 'media.mp4'
+            data_dict['media']['filetype'] = "mp4"
             try:
                 data_dict['media']['video_overlay'] = entry['snapInfo']['streamingMediaInfo']['prefixUrl'] + 'overlay.png'
             except:
@@ -17,6 +22,7 @@ def organise_media(api_data):
         except:
             try:
                 data_dict['media']['raw_url'] = entry['snapInfo']['publicMediaInfo']['publicImageMediaInfo']['mediaUrl']
+                data_dict['media']['filetype'] = "jpg"
             except:
                 for i in entry['snapInfo'].items():
                     if(i[0] == 'streamingThumbnailInfo'): # For some reason JSON throws an error if you just query this key directly, so you have to do it this way.


### PR DESCRIPTION
Added support for merging video and overlay file into one video file using ffmpeg. You can disable this using the --no-overlay argument. This solves #3
Also added `overlayText` and `filetype` fields to the `--write-json` argument.