### PR TITLE
Closes #21 Remove None assumption when empty list is returned

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "snapmap-archiver"
-version = "2.4.0"
+version = "2.4.1"
 description = "Download all Snap Map content from a specific location."
 readme = "README.md"
 authors = ["Miles Greenwark <Millez.Dev@gmail.com>"]

--- a/snapmap_archiver/SnapmapArchiver.py
+++ b/snapmap_archiver/SnapmapArchiver.py
@@ -203,7 +203,7 @@ class SnapmapArchiver:
                 self.logger.debug(f"[{current_iteration=}].")
                 snaps_from_coords = None
 
-                while not snaps_from_coords:
+                while snaps_from_coords is None:
                     request_object = {
                         "url": f"{self.api_host}/web/getPlaylist",
                         "headers": {


### PR DESCRIPTION
Thanks to @spectator8 for the detective work. This fixes a bug where if a snap query returns 0 snaps, snapmap-archiver will infinitely loop because of a `while not list` loop, rather than a `while list is None` loop.